### PR TITLE
Fix the password checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react-hot-loader": "3.1.1",
     "react-responsive": "3.0.0",
     "semantic-ui-react": "0.75.1",
+    "sha1": "1.1.1",
     "style-loader": "0.19.0",
     "webpack": "3.8.1",
     "webpack-dev-server": "2.9.3",
@@ -78,7 +79,9 @@
     }
   },
   "jest": {
-    "setupFiles": ["./src/jest-setup.js"]
+    "setupFiles": [
+      "./src/jest-setup.js"
+    ]
   },
   "prettier": {
     "bracketSpacing": false,

--- a/src/components/EmailChecker.js
+++ b/src/components/EmailChecker.js
@@ -98,7 +98,7 @@ class EmailChecker extends React.Component {
                   <Container text textAlign="left">
                       <Item.Group divided>
                           {this.state.breaches.map(breach => (
-                              <Item>
+                              <Item key={breach.Title}>
                                   <Item.Image
                                       shape="rounded"
                                       size="tiny"

--- a/src/components/PasswordChecker.js
+++ b/src/components/PasswordChecker.js
@@ -19,7 +19,7 @@ class PasswordChecker extends React.Component {
             error: '',
             hasResult: false,
             loading: false,
-            pwned: false,
+            pwnedCount: null,
             rateLimited: false
         };
 
@@ -46,7 +46,7 @@ class PasswordChecker extends React.Component {
             error,
             hasResult: false,
             loading: !error,
-            pwned: false,
+            pwnedCount: null,
             rateLimited: !error
         });
 
@@ -58,7 +58,7 @@ class PasswordChecker extends React.Component {
             this.setState({
                 hasResult: true,
                 loading: false,
-                pwned: await pwnedPassword(password)
+                pwnedCount: await pwnedPassword(password)
             });
         } catch (error) {
             this.setState({
@@ -75,6 +75,25 @@ class PasswordChecker extends React.Component {
     }
 
     render() {
+        const pwned = Boolean(this.state.pwnedCount);
+
+        const header = pwned
+            ? `This password is compromised.`
+            : `As far as we know, this password has not been compromised.`;
+
+        let count = this.state.pwnedCount;
+        try {
+            if (count) {
+                count = new Intl.NumberFormat().format(count);
+            }
+        } catch (error) {
+            // eslint-disable-line no-empty
+        }
+
+        const message = pwned
+            ? `It has appeared at least ${count} times in breaches. It should never be used again.`
+            : `That's good news, but it could still be a bad password to use if it's too easy to guess.`;
+
         return (
             <Segment attached color="blue" textAlign="center">
                 <Header as="h3" content="Check a password" />
@@ -121,16 +140,10 @@ class PasswordChecker extends React.Component {
                 {this.state.hasResult ? (
                     <Message
                         compact
-                        positive={!this.state.pwned}
-                        negative={this.state.pwned}
-                        header={`This password has ${this.state.pwned
-                            ? ''
-                            : 'not'} been compromised`}
-                        content={
-                            this.state.pwned
-                                ? 'It should never be used again.'
-                                : `That's good news, but keep in mind it doesn't prove that this is a good password to use.`
-                        }
+                        positive={!pwned}
+                        negative={pwned}
+                        header={header}
+                        content={message}
                     />
                 ) : null}
             </Segment>

--- a/src/pwned.js
+++ b/src/pwned.js
@@ -1,3 +1,5 @@
+import sha1 from 'sha1';
+
 const API = 'https://haveibeenpwned.com/api/v2';
 export const RATE_LIMIT_MS = 1510;
 
@@ -49,14 +51,25 @@ export function getPasteUrl(source, id) {
 }
 
 export async function pwnedPassword(password) {
+    const targetHash = sha1(password).toUpperCase();
+
     const response = await fetch(
-        `${API}/pwnedpassword/${encodeURIComponent(password)}`
+        `https://api.pwnedpasswords.com/range/${targetHash.substr(0, 5)}`
     );
-    if (response.status === 200) {
-        return true;
-    } else if (response.status === 404) {
-        return false;
-    } else {
+
+    if (response.status !== 200) {
         return Promise.reject({responseCode: response.status});
     }
+
+    const body = await response.text();
+    const targetSuffix = targetHash.substring(5);
+
+    for (const line of body.split(/\r?\n/)) {
+        const [suffix, count] = line.split(':');
+        if (suffix === targetSuffix) {
+            return count;
+        }
+    }
+
+    return 0;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1174,6 +1174,10 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0:
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
 
+"charenc@>= 0.0.1":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -1441,6 +1445,10 @@ cross-spawn@^5.0.1, cross-spawn@^5.1.0:
     lru-cache "^4.0.1"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+"crypt@>= 0.0.1":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -5150,6 +5158,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+sha1@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sha1/-/sha1-1.1.1.tgz#addaa7a93168f393f19eb2b15091618e2700f848"
+  dependencies:
+    charenc ">= 0.0.1"
+    crypt ">= 0.0.1"
 
 shebang-command@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
The old API is retired, so we need to switch to the new one that uses a [k-anonymity](https://en.wikipedia.org/wiki/K-anonymity) approach. See Troy Hunt's [blog post](https://www.troyhunt.com/enhancing-pwned-passwords-privacy-by-exclusively-supporting-anonymity/) regarding the retirement of the old API.
